### PR TITLE
Fix MQTT requirement in manifest

### DIFF
--- a/custom_components/anycubic_cloud/manifest.json
+++ b/custom_components/anycubic_cloud/manifest.json
@@ -15,6 +15,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/WaresWichall/anycubic_cloud/issues",
   "loggers": [],
-  "requirements": ["paho-mqtt==1.6.1"],
+  "requirements": ["paho-mqtt==2.1.0"],
   "version": "0.2.2"
 }


### PR DESCRIPTION
## Summary
- bump `paho-mqtt` version in manifest

## Testing
- `pre-commit run --files custom_components/anycubic_cloud/manifest.json` *(fails: CalledProcessError installing homeassistant)*

------
https://chatgpt.com/codex/tasks/task_b_68836214548c832180332cc9e3d281e4