### PR TITLE
Fix generic syntax for Python 3.11

### DIFF
--- a/custom_components/anycubic_cloud/coordinator.py
+++ b/custom_components/anycubic_cloud/coordinator.py
@@ -5,7 +5,7 @@ import asyncio
 import time
 import traceback
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from aiohttp import CookieJar
 from homeassistant.config_entries import ConfigEntry
@@ -74,6 +74,8 @@ from .helpers import (
 if TYPE_CHECKING:
     from .anycubic_cloud_api.data_models.printer import AnycubicPrinter
     from .entity import AnycubicCloudEntity, AnycubicCloudEntityDescription
+
+_AnycubicCloudEntityT = TypeVar("_AnycubicCloudEntityT", bound="AnycubicCloudEntity")
 
 
 class AnycubicCloudDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
@@ -417,7 +419,7 @@ class AnycubicCloudDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.async_update_listeners()
 
     @callback
-    def add_entities_for_seen_printers[_AnycubicCloudEntityT: AnycubicCloudEntity](
+    def add_entities_for_seen_printers(
         self,
         async_add_entities: AddEntitiesCallback,
         entity_constructor: type[_AnycubicCloudEntityT],

--- a/custom_components/anycubic_cloud/helpers.py
+++ b/custom_components/anycubic_cloud/helpers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from enum import IntEnum
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 
@@ -20,6 +20,8 @@ if TYPE_CHECKING:
     from .coordinator import AnycubicCloudDataUpdateCoordinator
     from .entity import AnycubicCloudEntityDescription
 
+
+_T = TypeVar("_T")
 
 class AnycubicMQTTConnectMode(IntEnum):
     Printing_Only = 1
@@ -255,7 +257,7 @@ def remove_quotes_from_string(input_string: str) -> str:
     raise TypeError("Unexpected quotes in string.")
 
 
-def validate_value_is_type[_T: Any](
+def validate_value_is_type(
     value: Any,
     value_type: type[_T],
     allow_lists: bool = False,
@@ -271,7 +273,7 @@ def validate_value_is_type[_T: Any](
     return None
 
 
-def get_value_from_dict_if_type[_T: Any](
+def get_value_from_dict_if_type(
     input_dict: dict[str, Any],
     key: str,
     value_type: type[_T],


### PR DESCRIPTION
## Summary
- fix newer generic syntax that caused SyntaxError on Python 3.11

## Testing
- `python -m py_compile custom_components/anycubic_cloud/helpers.py`
- `python -m py_compile custom_components/anycubic_cloud/coordinator.py`
- `pre-commit run --files custom_components/anycubic_cloud/helpers.py custom_components/anycubic_cloud/coordinator.py` *(fails: CalledProcessError when installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_688361af361c8321854f7dc47b1b0cc3