### PR TITLE
Fix sensor native_value docstring

### DIFF
--- a/custom_components/anycubic_cloud/sensor.py
+++ b/custom_components/anycubic_cloud/sensor.py
@@ -345,7 +345,7 @@ class AnycubicSensor(AnycubicCloudEntity, SensorEntity):
 
     @property
     def native_value(self) -> Any:
-        """Return the ...."""
+        """Return the native sensor value."""
         state = printer_state_for_key(self.coordinator, self._printer_id, self.entity_description.key)
 
         if state is None:


### PR DESCRIPTION
## Summary
- update placeholder docstring in sensor

## Testing
- `flake8 custom_components/anycubic_cloud/sensor.py`
- `pre-commit run --files custom_components/anycubic_cloud/sensor.py` *(fails: Could not install homeassistant==2024.9.3)*

------
https://chatgpt.com/codex/tasks/task_b_6883638e73088321ba877b6b7f152788