### PR TITLE
Fix file_id field in __repr__

### DIFF
--- a/custom_components/anycubic_cloud/anycubic_cloud_api/data_models/orders.py
+++ b/custom_components/anycubic_cloud/anycubic_cloud_api/data_models/orders.py
@@ -310,7 +310,7 @@ class AnycubicStartPrintRequestCloud(AnycubicBaseStartPrintRequest):
         return (
             f"AnycubicStartPrintRequestCloud("
             f"filetype={self._filetype}, "
-            f"file_id={self._file_name}, "
+            f"file_id={self._file_id}, "
             f"task_settings={self.task_settings})"
         )
 


### PR DESCRIPTION
## Summary
- correct `file_id` reporting in `AnycubicStartPrintRequestCloud.__repr__`

## Testing
- `flake8 custom_components/anycubic_cloud/anycubic_cloud_api/data_models/orders.py`
- `pre-commit run --files custom_components/anycubic_cloud/anycubic_cloud_api/data_models/orders.py` *(fails: calledprocesserror building Home Assistant)*

------
https://chatgpt.com/codex/tasks/task_b_6883638a1bf8832190637a6e9d4acb63