### PR TITLE
Update frontend tabs to ha-tab elements

### DIFF
--- a/custom_components/anycubic_cloud/frontend_panel/dist/anycubic-card.js
+++ b/custom_components/anycubic_cloud/frontend_panel/dist/anycubic-card.js
@@ -9591,11 +9591,9 @@
           .selected=${this.configPage}
           @iron-activate=${this._handlePageSelected}
         >
-          <paper-tab page-name="main">${this._tabMain}</paper-tab>
-          <paper-tab page-name="stats">${this._tabStats}</paper-tab>
-          ${this.hasColorbox ? K`<paper-tab page-name="colours">
-                ${this._tabColours}
-              </paper-tab>` : q}
+          <ha-tab page-name="main">${this._tabMain}</ha-tab>
+          <ha-tab page-name="stats">${this._tabStats}</ha-tab>
+          ${this.hasColorbox ? K`<ha-tab page-name="colours"> ${this._tabColours} </ha-tab>` : q}
         </ha-tabs>
       </div>
     `;

--- a/custom_components/anycubic_cloud/frontend_panel/dist/anycubic-cloud-panel.js
+++ b/custom_components/anycubic_cloud/frontend_panel/dist/anycubic-cloud-panel.js
@@ -9921,22 +9921,16 @@
           .selected=${this.selectedPage}
           @iron-activate=${this.handlePageSelected}
         >
-          <paper-tab page-name="main"> ${this._tabMain} </paper-tab>
-          <paper-tab page-name="local-files">
-            ${this._tabFilesLocal}
-          </paper-tab>
-          <paper-tab page-name="udisk-files">
-            ${this._tabFilesUdisk}
-          </paper-tab>
-          <paper-tab page-name="cloud-files">
-            ${this._tabFilesCloud}
-          </paper-tab>
-          <paper-tab page-name="print-no_cloud_save">
+          <ha-tab page-name="main"> ${this._tabMain} </ha-tab>
+          <ha-tab page-name="local-files"> ${this._tabFilesLocal} </ha-tab>
+          <ha-tab page-name="udisk-files"> ${this._tabFilesUdisk} </ha-tab>
+          <ha-tab page-name="cloud-files"> ${this._tabFilesCloud} </ha-tab>
+          <ha-tab page-name="print-no_cloud_save">
             ${this._tabPrintNoSave}
-          </paper-tab>
-          <paper-tab page-name="print-save_in_cloud">
+          </ha-tab>
+          <ha-tab page-name="print-save_in_cloud">
             ${this._tabPrintSave}
-          </paper-tab>
+          </ha-tab>
           ${null}
         </ha-tabs>
       </div>

--- a/custom_components/anycubic_cloud/frontend_panel/src/anycubic-cloud-panel.ts
+++ b/custom_components/anycubic_cloud/frontend_panel/src/anycubic-cloud-panel.ts
@@ -162,26 +162,18 @@ export class AnycubicCloudPanel extends LitElement {
           .selected=${this.selectedPage}
           @iron-activate=${this.handlePageSelected}
         >
-          <paper-tab page-name="main"> ${this._tabMain} </paper-tab>
-          <paper-tab page-name="local-files">
-            ${this._tabFilesLocal}
-          </paper-tab>
-          <paper-tab page-name="udisk-files">
-            ${this._tabFilesUdisk}
-          </paper-tab>
-          <paper-tab page-name="cloud-files">
-            ${this._tabFilesCloud}
-          </paper-tab>
-          <paper-tab page-name="print-no_cloud_save">
+          <ha-tab page-name="main"> ${this._tabMain} </ha-tab>
+          <ha-tab page-name="local-files"> ${this._tabFilesLocal} </ha-tab>
+          <ha-tab page-name="udisk-files"> ${this._tabFilesUdisk} </ha-tab>
+          <ha-tab page-name="cloud-files"> ${this._tabFilesCloud} </ha-tab>
+          <ha-tab page-name="print-no_cloud_save">
             ${this._tabPrintNoSave}
-          </paper-tab>
-          <paper-tab page-name="print-save_in_cloud">
+          </ha-tab>
+          <ha-tab page-name="print-save_in_cloud">
             ${this._tabPrintSave}
-          </paper-tab>
+          </ha-tab>
           ${DEBUG // eslint-disable-line @typescript-eslint/no-unnecessary-condition
-            ? html`
-                <paper-tab page-name="debug"> ${this._tabDebug} </paper-tab>
-              `
+            ? html` <ha-tab page-name="debug"> ${this._tabDebug} </ha-tab> `
             : null}
         </ha-tabs>
       </div>

--- a/custom_components/anycubic_cloud/frontend_panel/src/components/printer_card/configure/configure.ts
+++ b/custom_components/anycubic_cloud/frontend_panel/src/components/printer_card/configure/configure.ts
@@ -296,12 +296,10 @@ export class AnycubicPrintercardConfigure extends LitElement {
           .selected=${this.configPage}
           @iron-activate=${this._handlePageSelected}
         >
-          <paper-tab page-name="main">${this._tabMain}</paper-tab>
-          <paper-tab page-name="stats">${this._tabStats}</paper-tab>
+          <ha-tab page-name="main">${this._tabMain}</ha-tab>
+          <ha-tab page-name="stats">${this._tabStats}</ha-tab>
           ${this.hasColorbox
-            ? html`<paper-tab page-name="colours">
-                ${this._tabColours}
-              </paper-tab>`
+            ? html`<ha-tab page-name="colours"> ${this._tabColours} </ha-tab>`
             : nothing}
         </ha-tabs>
       </div>


### PR DESCRIPTION
## Summary
- replace paper-tab elements with ha-tab in TypeScript sources
- rebuild dist JS files

## Testing
- `npm run build`
- `npm run build_card`
- `pre-commit run --files custom_components/anycubic_cloud/frontend_panel/src/anycubic-cloud-panel.ts custom_components/anycubic_cloud/frontend_panel/src/components/printer_card/configure/configure.ts` *(fails: Could not install Home Assistant)*

------
https://chatgpt.com/codex/tasks/task_b_688367a636288321845848b626ad1445