### PR TITLE
Add HasTabs interface and use in page selection

### DIFF
--- a/custom_components/anycubic_cloud/frontend_panel/src/anycubic-cloud-panel.ts
+++ b/custom_components/anycubic_cloud/frontend_panel/src/anycubic-cloud-panel.ts
@@ -22,6 +22,7 @@ import {
 import {
   DomClickEvent,
   EvtTargPrinterDevId,
+  HasTabs,
   HassDevice,
   HassDeviceList,
   HassPanel,
@@ -332,9 +333,7 @@ export class AnycubicCloudPanel extends LitElement {
 
   handlePageSelected = (ev: HASSDomEvent<PageChangeDetail>): void => {
     const index = ev.detail.index;
-    const tab = (ev.currentTarget as unknown as { tabs: HTMLElement[] }).tabs[
-      index
-    ];
+    const tab = (ev.currentTarget as unknown as HasTabs).tabs[index];
     const newPage = tab.getAttribute("page-name") as string;
     if (newPage !== getPage(this.route)) {
       navigateToPage(this, newPage);

--- a/custom_components/anycubic_cloud/frontend_panel/src/components/printer_card/configure/configure.ts
+++ b/custom_components/anycubic_cloud/frontend_panel/src/components/printer_card/configure/configure.ts
@@ -24,6 +24,7 @@ import {
   CalculatedTimeType,
   FormChangeDetail,
   HaFormBaseSchema,
+  HasTabs,
   HassDeviceList,
   HassEntityInfos,
   HomeAssistant,
@@ -308,9 +309,7 @@ export class AnycubicPrintercardConfigure extends LitElement {
 
   private _handlePageSelected = (ev: HASSDomEvent<PageChangeDetail>): void => {
     const index = ev.detail.index;
-    const tab = (ev.currentTarget as unknown as { tabs: HTMLElement[] }).tabs[
-      index
-    ];
+    const tab = (ev.currentTarget as unknown as HasTabs).tabs[index];
     const newPage = tab.getAttribute("page-name") as string;
     if (newPage !== this.configPage) {
       this.configPage = newPage;

--- a/custom_components/anycubic_cloud/frontend_panel/src/types.ts
+++ b/custom_components/anycubic_cloud/frontend_panel/src/types.ts
@@ -464,3 +464,7 @@ export interface EvtTargSpoolEdit extends EventTarget {
 export interface EvtTargColourPreset extends EventTarget {
   preset: string;
 }
+
+export interface HasTabs {
+  tabs: HTMLElement[];
+}


### PR DESCRIPTION
## Summary
- add a new `HasTabs` interface for elements that expose `tabs`
- use `HasTabs` when handling tab selection in the panel and card configuration

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68842cc8f7fc8321840f30bec129f8a3