### PR TITLE
Handle ha-tabs selected events

### DIFF
--- a/custom_components/anycubic_cloud/frontend_panel/src/anycubic-cloud-panel.ts
+++ b/custom_components/anycubic_cloud/frontend_panel/src/anycubic-cloud-panel.ts
@@ -333,7 +333,7 @@ export class AnycubicCloudPanel extends LitElement {
 
   handlePageSelected = (ev: HASSDomEvent<PageChangeDetail>): void => {
     const index = ev.detail.index;
-    const tabId = (ev.detail as unknown as { tabId?: string }).tabId;
+    const tabId = ev.detail.tabId;
     const tabsEl = ev.currentTarget as HTMLElement;
     let tab: Element | null = null;
     if (tabId) {

--- a/custom_components/anycubic_cloud/frontend_panel/src/components/printer_card/configure/configure.ts
+++ b/custom_components/anycubic_cloud/frontend_panel/src/components/printer_card/configure/configure.ts
@@ -309,7 +309,7 @@ export class AnycubicPrintercardConfigure extends LitElement {
 
   private _handlePageSelected = (ev: HASSDomEvent<PageChangeDetail>): void => {
     const index = ev.detail.index;
-    const tabId = (ev.detail as unknown as { tabId?: string }).tabId;
+    const tabId = ev.detail.tabId;
     const tabsEl = ev.currentTarget as HTMLElement;
     let tab: Element | null = null;
     if (tabId) {

--- a/custom_components/anycubic_cloud/frontend_panel/src/types.ts
+++ b/custom_components/anycubic_cloud/frontend_panel/src/types.ts
@@ -370,6 +370,7 @@ export interface HassPanel {
 
 export interface PageChangeDetail {
   index: number;
+  tabId?: string;
 }
 
 export interface ModalEventBase {


### PR DESCRIPTION
## Summary
- propagate optional tabId on page change events
- use new tabId when selecting pages

## Testing
- `pre-commit run --files custom_components/anycubic_cloud/frontend_panel/src/types.ts custom_components/anycubic_cloud/frontend_panel/src/anycubic-cloud-panel.ts custom_components/anycubic_cloud/frontend_panel/src/components/printer_card/configure/configure.ts` *(fails: CalledProcessError during mypy environment install)*

------
https://chatgpt.com/codex/tasks/task_b_6884c8740500832195a74fb37650b7bb