### PR TITLE
Update tab selection logic

### DIFF
--- a/custom_components/anycubic_cloud/frontend_panel/src/anycubic-cloud-panel.ts
+++ b/custom_components/anycubic_cloud/frontend_panel/src/anycubic-cloud-panel.ts
@@ -350,16 +350,12 @@ export class AnycubicCloudPanel extends LitElement {
   };
 
   handlePageSelected = (ev: HASSDomEvent<PageChangeDetail>): void => {
-    const index = ev.detail.index;
-    const tabId = ev.detail.tabId;
-    const tabsEl = ev.currentTarget as HTMLElement;
-    let tab: Element | null = null;
-    if (tabId) {
-      tab = tabsEl.querySelector(`ha-tab#${tabId}`);
-    }
-    if (!tab) {
-      tab = tabsEl.children[index] as Element | null;
-    }
+    const tab = (ev
+      .composedPath()
+      .find(
+        (el) =>
+          (el as HTMLElement).getAttribute?.("page-name") !== null,
+      ) as HTMLElement | undefined);
     const newPage = tab?.getAttribute("page-name");
     if (newPage && newPage !== getPage(this.route)) {
       navigateToPage(this, newPage);

--- a/custom_components/anycubic_cloud/frontend_panel/src/components/printer_card/configure/configure.ts
+++ b/custom_components/anycubic_cloud/frontend_panel/src/components/printer_card/configure/configure.ts
@@ -314,16 +314,12 @@ export class AnycubicPrintercardConfigure extends LitElement {
   }
 
   private _handlePageSelected = (ev: HASSDomEvent<PageChangeDetail>): void => {
-    const index = ev.detail.index;
-    const tabId = ev.detail.tabId;
-    const tabsEl = ev.currentTarget as HTMLElement;
-    let tab: Element | null = null;
-    if (tabId) {
-      tab = tabsEl.querySelector(`ha-tab#${tabId}`);
-    }
-    if (!tab) {
-      tab = tabsEl.children[index] as Element | null;
-    }
+    const tab = (ev
+      .composedPath()
+      .find(
+        (el) =>
+          (el as HTMLElement).getAttribute?.("page-name") !== null,
+      ) as HTMLElement | undefined);
     const newPage = tab?.getAttribute("page-name");
     if (newPage && newPage !== this.configPage) {
       this.configPage = newPage;


### PR DESCRIPTION
## Summary
- improve tab selection by using the event's composed path in the main panel
- update the printer card configure view to use the same lookup

## Testing
- `pre-commit run --files custom_components/anycubic_cloud/frontend_panel/src/anycubic-cloud-panel.ts custom_components/anycubic_cloud/frontend_panel/src/components/printer_card/configure/configure.ts` *(fails: Could not find a version that satisfies the requirement homeassistant==2024.9.3)*

------
https://chatgpt.com/codex/tasks/task_b_6884e04911208321837d3bf3a4f7a7cf