### PR TITLE
Fix header z-index so tabs remain clickable

### DIFF
--- a/custom_components/anycubic_cloud/frontend_panel/dist/anycubic-card.js
+++ b/custom_components/anycubic_cloud/frontend_panel/dist/anycubic-card.js
@@ -9496,10 +9496,7 @@
   let so = class extends pt {
     constructor() {
       super(...arguments), this.configPage = "main", this.availableStats = {}, this.formSchemaMain = [], this.formSchemaColours = [], this.hasColorbox = !1, this.isLCD = !1, this._handlePageSelected = t => {
-        const e = t.composedPath().find(t => {
-            var e, i;
-            return null !== (null === (i = (e = t).getAttribute) || void 0 === i ? void 0 : i.call(e, "page-name"));
-          }),
+        const e = t.composedPath().find(t => null !== t.getAttribute("page-name")),
           i = null == e ? void 0 : e.getAttribute("page-name");
         i && i !== this.configPage && (this.configPage = i);
       }, this._selectedStatsChanged = t => {
@@ -9728,6 +9725,8 @@
 
       .header {
         color: var(--primary-text-color);
+        position: relative;
+        z-index: 1;
         margin-top: var(--header-height);
       }
 

--- a/custom_components/anycubic_cloud/frontend_panel/dist/anycubic-cloud-panel.js
+++ b/custom_components/anycubic_cloud/frontend_panel/dist/anycubic-cloud-panel.js
@@ -9880,10 +9880,7 @@
           });
         })(this, t.currentTarget.printer_id), this.requestUpdate();
       }, this.handlePageSelected = t => {
-        const e = t.composedPath().find(t => {
-            var e, i;
-            return null !== (null === (i = (e = t).getAttribute) || void 0 === i ? void 0 : i.call(e, "page-name"));
-          }),
+        const e = t.composedPath().find(t => null !== t.getAttribute("page-name")),
           i = null == e ? void 0 : e.getAttribute("page-name");
         i && i !== mi(this.route) ? (((t, e, i = !1) => {
           const r = t.route.prefix,
@@ -10098,6 +10095,8 @@
         background-color: var(--app-header-background-color);
         color: var(--app-header-text-color, white);
         border-bottom: var(--app-header-border-bottom, none);
+        position: relative;
+        z-index: 1;
         margin-top: var(--header-height);
       }
       .toolbar {

--- a/custom_components/anycubic_cloud/frontend_panel/src/anycubic-cloud-panel.ts
+++ b/custom_components/anycubic_cloud/frontend_panel/src/anycubic-cloud-panel.ts
@@ -374,6 +374,8 @@ export class AnycubicCloudPanel extends LitElement {
         background-color: var(--app-header-background-color);
         color: var(--app-header-text-color, white);
         border-bottom: var(--app-header-border-bottom, none);
+        position: relative;
+        z-index: 1;
         margin-top: var(--header-height);
       }
       .toolbar {

--- a/custom_components/anycubic_cloud/frontend_panel/src/components/printer_card/configure/configure.ts
+++ b/custom_components/anycubic_cloud/frontend_panel/src/components/printer_card/configure/configure.ts
@@ -499,6 +499,8 @@ export class AnycubicPrintercardConfigure extends LitElement {
 
       .header {
         color: var(--primary-text-color);
+        position: relative;
+        z-index: 1;
         margin-top: var(--header-height);
       }
 


### PR DESCRIPTION
## Summary
- keep panel header above content so tabs work
- ensure printer card header stays above underlying tabs

## Testing
- `npm run build && npm run build_card`
- `pre-commit run --files custom_components/anycubic_cloud/frontend_panel/src/anycubic-cloud-panel.ts custom_components/anycubic_cloud/frontend_panel/src/components/printer_card/configure/configure.ts custom_components/anycubic_cloud/frontend_panel/dist/anycubic-cloud-panel.js custom_components/anycubic_cloud/frontend_panel/dist/anycubic-card.js` *(fails: Could not find a version that satisfies the requirement homeassistant==2024.9.3)*

------
https://chatgpt.com/codex/tasks/task_b_68853558110083218e892a96a9eb7f04