### PR TITLE
Update development instructions

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,11 +2,34 @@
 
 Currently building using node version v18.20.4
 
+## Prerequisites
+
+Install the `pre-commit` tool and enable the hooks:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Check your changes with:
+
+```bash
+pre-commit run --files <changed files>
+```
+
+Ensure `custom_components/anycubic_cloud/frontend_panel/package.json` exists
+before running any `npm` script.
+
 Open a terminal inside the `custom_components/anycubic_cloud/frontend_panel` directory.
 
 Run:
 ```bash
 npm install
+```
+
+After installing dependencies, build the panel with:
+```bash
+npm run build
 ```
 
 Build both the panel and the card using the command:


### PR DESCRIPTION
## Summary
- add prerequisites for `pre-commit` and `npm` scripts
- show example `pre-commit run` and quick `npm` build commands

## Testing
- `pre-commit run --files DEVELOPMENT.md` *(fails: Could not find homeassistant==2024.9.3)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68860e43099883219fa97b706034b98a