### PR TITLE
Fix sl-tab text colors

### DIFF
--- a/custom_components/anycubic_cloud/frontend_panel/src/anycubic-cloud-panel.ts
+++ b/custom_components/anycubic_cloud/frontend_panel/src/anycubic-cloud-panel.ts
@@ -393,6 +393,14 @@ export class AnycubicCloudPanel extends LitElement {
         text-transform: uppercase;
       }
 
+      sl-tab::part(base) {
+        color: var(--app-header-text-color, #fff);
+      }
+
+      sl-tab[active]::part(base) {
+        color: var(--app-header-text-color, #fff);
+      }
+
       .version {
         font-size: 14px;
         font-weight: 500;

--- a/custom_components/anycubic_cloud/frontend_panel/src/components/printer_card/configure/configure.ts
+++ b/custom_components/anycubic_cloud/frontend_panel/src/components/printer_card/configure/configure.ts
@@ -500,6 +500,14 @@ export class AnycubicPrintercardConfigure extends LitElement {
         text-transform: uppercase;
       }
 
+      sl-tab::part(base) {
+        color: var(--primary-text-color);
+      }
+
+      sl-tab[active]::part(base) {
+        color: var(--primary-text-color);
+      }
+
       .ac-printer-card-configure-conf {
         margin-top: 10px;
       }


### PR DESCRIPTION
## Summary
- ensure active `sl-tab` text color uses header text color
- match config tab color with the rest of the header

## Testing
- `pre-commit` *(fails: Could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_688615028c548321a77cbfceeb47fa31