### PR TITLE
fix: ensure camera entities always registered

### DIFF
--- a/custom_components/anycubic_cloud/button.py
+++ b/custom_components/anycubic_cloud/button.py
@@ -101,14 +101,14 @@ CAMERA_BUTTON_TYPES: list[AnycubicButtonEntityDescription] = [
         translation_key="start_camera",
         icon=ICON_CAM_START,
         printer_entity_type=PrinterEntityType.PRINTER,
-        requires_peripheral_camera=True,
+        requires_peripheral_camera=False,
     ),
     AnycubicButtonEntityDescription(
         key="stop_camera",
         translation_key="stop_camera",
         icon=ICON_CAM_STOP,
         printer_entity_type=PrinterEntityType.PRINTER,
-        requires_peripheral_camera=True,
+        requires_peripheral_camera=False,
     ),
 ]
 

--- a/custom_components/anycubic_cloud/camera.py
+++ b/custom_components/anycubic_cloud/camera.py
@@ -34,10 +34,10 @@ _REFRESH = timedelta(minutes=55)
 
 CAMERA_TYPES: list[AnycubicCloudEntityDescription] = [
     AnycubicCloudEntityDescription(
-        key="camera",
+        key="camera_stream",  # stable key -> unique_id ends _camera
         translation_key="camera",
         printer_entity_type=PrinterEntityType.PRINTER,
-        requires_peripheral_camera=True,
+        requires_peripheral_camera=False,
     )
 ]
 
@@ -165,6 +165,7 @@ class AnycubicCloudCamera(AnycubicCloudEntity, Camera):
         printer = self.coordinator.get_printer_for_id(printer_id)
         if printer:
             self._attr_unique_id = f"{printer.machine_mac}_camera"
+        self._attr_name = "Camera"
 
     async def async_added_to_hass(self) -> None:
         await self._refresh()


### PR DESCRIPTION
## Summary
- always register camera entity and start/stop camera buttons
- provide default name and stable key for camera entity

## Testing
- `pre-commit run --files custom_components/anycubic_cloud/camera.py custom_components/anycubic_cloud/button.py` *(failed: CalledProcessError: command: ('/root/.cache/pre-commit/repo340jy01_/py_env-python3.11/bin/python', '-mpip', 'install', '.', 'homeassistant==2024.9.3', 'pydantic==2.9.2', 'aiofiles==24.1.0', 'types-aiofiles==24.1.0.20240626', 'types-paho-mqtt==1.6.0.20240321')...)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_688bba6b46e483218e5ced0313320396