### PR TITLE
Add Anycubic camera control orders

### DIFF
--- a/custom_components/anycubic_cloud/api/mqtt.py
+++ b/custom_components/anycubic_cloud/api/mqtt.py
@@ -1,0 +1,19 @@
+"""MQTT API helpers for Anycubic Cloud integration."""
+
+from __future__ import annotations
+
+from ..anycubic_cloud_api.anycubic_api import AnycubicMQTTAPI as AnycubicBaseAPI
+
+
+class AnycubicMQTTAPI(AnycubicBaseAPI):
+    """MQTT helper."""
+
+    # ------------------------------------------------------------------
+    # Orders such as CAMERA_OPEN (1001) are still executed over the
+    # Cloud HTTP API.  Provide a passthrough so callers don’t care
+    # which API variant they’re holding.
+    # ------------------------------------------------------------------
+    async def async_send_order(self, order_id: int, device_id: str | None = None):
+        """Delegate to underlying Cloud API for order calls."""
+        return await super().async_send_order(order_id, device_id=device_id)
+

--- a/custom_components/anycubic_cloud/coordinator.py
+++ b/custom_components/anycubic_cloud/coordinator.py
@@ -898,13 +898,21 @@ class AnycubicCloudDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 await self._connect_mqtt_for_action_response()
                 await printer.cancel_print()
 
-            elif printer and event_key == 'start_camera':
+            elif printer and event_key == "start_camera":
+                LOGGER.debug("[%s] Sending CAMERA_OPEN (1001)", printer_id)
                 await self.anycubic_api.async_send_order(
-                    AnycubicOrderID.CAMERA_OPEN, device_id=printer.id
+                    AnycubicOrderID.CAMERA_OPEN, device_id=printer_id
                 )
-            elif printer and event_key == 'stop_camera':
+                LOGGER.info(
+                    "[%s] Camera stream requested (order 1001 sent)", printer_id
+                )
+            elif printer and event_key == "stop_camera":
+                LOGGER.debug("[%s] Sending CAMERA_CLOSE (1002)", printer_id)
                 await self.anycubic_api.async_send_order(
-                    AnycubicOrderID.CAMERA_CLOSE, device_id=printer.id
+                    AnycubicOrderID.CAMERA_CLOSE, device_id=printer_id
+                )
+                LOGGER.info(
+                    "[%s] Camera stop requested (order 1002 sent)", printer_id
                 )
 
             # elif printer and event_key == 'toggle_auto_feed':


### PR DESCRIPTION
## Summary
- handle start/stop camera button presses by sending order IDs 1001/1002 and log actions
- add MQTT API passthrough wrapper exposing async_send_order

## Testing
- `pre-commit run --files custom_components/anycubic_cloud/coordinator.py custom_components/anycubic_cloud/api/mqtt.py` *(fails: Could not find a version that satisfies the requirement homeassistant==2024.9.3)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_688bfbc1e99c8321ab5c577762eb832f